### PR TITLE
Change condition to prevent loop when element dragged out of container

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -576,7 +576,7 @@ function getElementBehindPoint (point, x, y) {
     var maybeElem;
     while (el && el.shadowRoot) {
       maybeElem = el.shadowRoot.elementFromPoint(x, y);
-      if (maybeElem) {
+      if (maybeElem && el != maybeElem) {
         el = maybeElem;
       } else {
         return el;


### PR DESCRIPTION
When I dragged an element out of any dragula containers, the while loop would never end, because of the transparent preview of dragula.